### PR TITLE
Add GitHub Pages site to allowed CORS origins

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
             "https://tianna-unretractive-ellen.ngrok-free.dev",
             "http://localhost:3000",
             "http://localhost:5173",
+            "https://repowise.github.io/RepoWise-website/",
         ],
         env="CORS_ORIGINS",
     )


### PR DESCRIPTION
## Summary
- add RepoWise GitHub Pages deployment to the default CORS allow list for the API

## Testing
- not run (not requested)