### PR TITLE
Add public user count endpoint

### DIFF
--- a/app/api/auth_routes.py
+++ b/app/api/auth_routes.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import secrets
 from typing import Dict, List
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from loguru import logger
 
@@ -75,6 +76,13 @@ async def signup(user_data: UserSignupRequest, db: Session = Depends(get_db)):
         access_token=access_token,
         user=UserResponse.from_orm(new_user)
     )
+
+
+@router.get("/users/count")
+async def get_user_count(db: Session = Depends(get_db)):
+    """Public endpoint returning total number of users."""
+    count = db.query(func.count(User.id)).scalar() or 0
+    return {"count": count}
 
 
 @router.post("/login", response_model=TokenResponse)


### PR DESCRIPTION
## Summary
- add unauthenticated endpoint to return total user count
- compute count directly from database for quick status access

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fcb151b54832a950959da23544014)